### PR TITLE
Ensure ExpirationTokens, PostEvictionCallbacks are not null

### DIFF
--- a/src/MemoryCache.Testing.Common/CacheEntryFake.cs
+++ b/src/MemoryCache.Testing.Common/CacheEntryFake.cs
@@ -25,6 +25,8 @@ namespace MemoryCache.Testing.Common
             EnsureArgument.IsNotNull(key, nameof(key));
 
             Key = key;
+            ExpirationTokens = new List<IChangeToken>();
+            PostEvictionCallbacks = new List<PostEvictionCallbackRegistration>();
         }
 
         /// <summary>


### PR DESCRIPTION
When you use the current implementation and try to add a `PostEvictionCallbacks` an exception is thrown.